### PR TITLE
feat(Login): Make host and upload host configurable

### DIFF
--- a/src/app/modules/login/components/Login.js
+++ b/src/app/modules/login/components/Login.js
@@ -8,26 +8,38 @@ export default class Login extends Component {
   static propTypes = {
     accessToken: proptypes.string.isRequired,
     spaceId: proptypes.string.isRequired,
+    host: proptypes.string.isRequired,
+    hostUpload: proptypes.string.isRequired,
     setAccessToken: proptypes.func.isRequired,
+    setHost: proptypes.func.isRequired,
+    setHostUpload: proptypes.func.isRequired,
     setSpaceId: proptypes.func.isRequired,
     initClient: proptypes.func.isRequired
   }
   constructor (props) {
     super(props)
     this._onAccessTokenChange = this._onAccessTokenChange.bind(this)
-    this._onSpaceIdChance = this._onSpaceIdChance.bind(this)
+    this._onHostChange = this._onHostChange.bind(this)
+    this._onHostUploadChange = this._onHostUploadChange.bind(this)
+    this._onSpaceIdChange = this._onSpaceIdChange.bind(this)
     this._onFormSubmit = this._onFormSubmit.bind(this)
   }
   _onAccessTokenChange (e) {
     this.props.setAccessToken(e.target.value.trim())
   }
-  _onSpaceIdChance (e) {
+  _onHostChange (e) {
+    this.props.setHost(e.target.value.trim())
+  }
+  _onHostUploadChange (e) {
+    this.props.setHostUpload(e.target.value.trim())
+  }
+  _onSpaceIdChange (e) {
     this.props.setSpaceId(e.target.value.trim())
   }
   _onFormSubmit () {
     this.props.initClient()
   }
-  render ({ accessToken, spaceId }) {
+  render ({ accessToken, spaceId, host, hostUpload }) {
     return (
       <div>
         <div className={styles.wrapper}>
@@ -49,7 +61,23 @@ export default class Login extends Component {
               id='space-id'
               type='text'
               value={spaceId}
-              onChange={this._onSpaceIdChance} />
+              onChange={this._onSpaceIdChange} />
+          </div>
+          <div className={styles.group}>
+            <label htmlFor='host'>Host :</label>
+            <input
+              id='host'
+              type='text'
+              value={host}
+              onChange={this._onHostChange} />
+          </div>
+          <div className={styles.group}>
+            <label htmlFor='hostUpload'>Upload Host :</label>
+            <input
+              id='hostUpload'
+              type='text'
+              value={hostUpload}
+              onChange={this._onHostUploadChange} />
           </div>
           <div className={styles.group}>
             <input type='button' onClick={this._onFormSubmit} value='Connect' />

--- a/src/app/modules/login/index.js
+++ b/src/app/modules/login/index.js
@@ -1,14 +1,16 @@
 import { connect } from 'preact-redux'
 
-import { selectAccessToken, selectSpaceId } from 'store/contentful/selectors'
-import { setAccessToken, setSpaceId, INIT_CLIENT } from 'store/contentful/actions'
+import { selectAccessToken, selectSpaceId, selectHost, selectHostUpload } from 'store/contentful/selectors'
+import { setAccessToken, setSpaceId, setHost, setHostUpload, INIT_CLIENT } from 'store/contentful/actions'
 
 import Login from './components/Login'
 
 const mapStateToProps = (state, ownProps) => {
   return {
     accessToken: selectAccessToken(state),
-    spaceId: selectSpaceId(state)
+    spaceId: selectSpaceId(state),
+    host: selectHost(state),
+    hostUpload: selectHostUpload(state)
   }
 }
 
@@ -17,6 +19,16 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     setAccessToken: (accessToken) => {
       dispatch(setAccessToken({
         accessToken
+      }))
+    },
+    setHost: (host) => {
+      dispatch(setHost({
+        host
+      }))
+    },
+    setHostUpload: (hostUpload) => {
+      dispatch(setHostUpload({
+        hostUpload
       }))
     },
     setSpaceId: (spaceId) => {

--- a/src/app/store/api.js
+++ b/src/app/store/api.js
@@ -3,10 +3,12 @@ import { createClient } from 'contentful-management'
 let client = null
 let space = null
 
-export async function initClient (accessToken, spaceId) {
+export async function initClient (accessToken, spaceId, host, hostUpload) {
   try {
     client = createClient({
-      accessToken
+      accessToken,
+      host,
+      hostUpload
     })
 
     space = await client.getSpace(spaceId)

--- a/src/app/store/contentful/actions.js
+++ b/src/app/store/contentful/actions.js
@@ -8,6 +8,12 @@ export const setAccessToken = createActionCreator(SET_ACCESS_TOKEN)
 export const SET_SPACE_ID = createDeltaAction(name, 'SET_SPACE_ID')
 export const setSpaceId = createActionCreator(SET_SPACE_ID)
 
+export const SET_HOST = createDeltaAction(name, 'SET_HOST')
+export const setHost = createActionCreator(SET_HOST)
+
+export const SET_UPLOAD_HOST = createDeltaAction(name, 'SET_UPLOAD_HOST')
+export const setHostUpload = createActionCreator(SET_UPLOAD_HOST)
+
 export const INIT_CLIENT = createSignalAction(name, 'INIT_CLIENT')
 
 export const DISPLAY_ASSETS = createSignalAction(name, 'DISPLAY_ASSETS')

--- a/src/app/store/contentful/config.js
+++ b/src/app/store/contentful/config.js
@@ -3,5 +3,7 @@ export const name = 'CONTENTFUL'
 export const initialState = {
   accessToken: null,
   spaceId: null,
+  host: 'api.contentful.com',
+  hostUpload: 'upload.contentful.com',
   assets: []
 }

--- a/src/app/store/contentful/reducer.js
+++ b/src/app/store/contentful/reducer.js
@@ -21,6 +21,22 @@ export default function contentfulReducer (state = initialState, action) {
       spaceId
     }
   }
+  if (type === actions.SET_HOST) {
+    const { host } = data
+
+    return {
+      ...state,
+      host
+    }
+  }
+  if (type === actions.SET_UPLOAD_HOST) {
+    const { hostUpload } = data
+
+    return {
+      ...state,
+      hostUpload
+    }
+  }
 
   if (type === actions.SET_ASSETS) {
     const { assets } = data

--- a/src/app/store/contentful/saga.js
+++ b/src/app/store/contentful/saga.js
@@ -25,12 +25,17 @@ function * initClientSaga (action) {
     yield put(setBusyMessage({message: 'Initializing CMA Client'}))
     const accessToken = yield select(selectors.selectAccessToken)
     const spaceId = yield select(selectors.selectSpaceId)
+    let host = yield select(selectors.selectHost)
+    let hostUpload = yield select(selectors.selectHostUpload)
+
+    host = host || 'api.contentful.com'
+    hostUpload = hostUpload || 'upload.contentful.com'
 
     if (!accessToken || !spaceId) {
       throw new Error('AccessToken and SpaceID must be provided.')
     }
 
-    yield initClient(accessToken, spaceId)
+    yield initClient(accessToken, spaceId, host, hostUpload)
     yield put(actions.INIT_CLIENT.success())
     yield put(actions.DISPLAY_ASSETS.request())
   } catch (error) {

--- a/src/app/store/contentful/selectors.js
+++ b/src/app/store/contentful/selectors.js
@@ -1,3 +1,5 @@
 export const selectAccessToken = (state) => state.contentful.accessToken
 export const selectSpaceId = (state) => state.contentful.spaceId
+export const selectHost = (state) => state.contentful.host
+export const selectHostUpload = (state) => state.contentful.hostUpload
 export const selectAssets = (state) => state.contentful.assets


### PR DESCRIPTION
This PR adds the possibility to specify the host that you want to test against, it will be very useful for internal use when we want to test something on staging. I actually used it to test if the asset payload bug is fixed on staging 💪🏽

The new login form will look like this.

![screen shot 2017-03-07 at 21 19 31](https://cloud.githubusercontent.com/assets/1156093/23676075/c7ba0e3a-037b-11e7-9ca8-db0b1a89a294.png)
